### PR TITLE
Integrate ClubHouse stories

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,13 +7,22 @@ github_adapter =
     SlackAutolinker.GitHub.Fake
   end
 
+clubhouse_adapter =
+  if Mix.env == :prod do
+    SlackAutolinker.ClubHouse.Real
+  else
+    SlackAutolinker.ClubHouse.Fake
+  end
+
 config :slack_autolinker,
   port: (System.get_env("PORT") || "4000") |> String.to_integer,
-  repo_aliases: (System.get_env("BOT_REPO_ALIASES") || "{}"),
+  github_repo_aliases: (System.get_env("GITHUB_REPO_ALIASES") || "{}"),
+  clubhouse_project_aliases: (System.get_env("CLUBHOUSE_PROJECT_ALIASES") || "{}"),
   username: (System.get_env("BOT_USERNAME") || "autolinker"),
   icon_emoji: (System.get_env("BOT_ICON_EMOJI") || ":anchor:"),
   icon_url: System.get_env("BOT_ICON_URL"), # if present, overwrites icon_emoji
   github_adapter: github_adapter,
-  github_token: (System.get_env("GITHUB_TOKEN") || raise "GITHUB_TOKEN missing")
+  github_token: (System.get_env("GITHUB_TOKEN") || raise "GITHUB_TOKEN missing"),
+  clubhouse_adapter: clubhouse_adapter
 
 import_config "#{Mix.env}.exs"

--- a/lib/slack_autolinker.ex
+++ b/lib/slack_autolinker.ex
@@ -4,62 +4,92 @@ defmodule SlackAutolinker do
     "ecto" => "elixir-ecto/ecto",
     "phoenix" => "phoenixframework/phoenix",
   }
-  @github Application.get_env(:slack_autolinker, :github_adapter)
 
-  alias SlackAutolinker.GitHub.Issue
+  alias SlackAutolinker.ClubHouse
+  alias SlackAutolinker.GitHub
+
+  @github Application.get_env(:slack_autolinker, :github_adapter)
+  @clubhouse Application.get_env(:slack_autolinker, :clubhouse_adapter)
+
+  @project_pattern "([a-z]+[a-z0-9-_\.]*[a-z0-9]*)"
+
   require Logger
 
-  def reply(text, repo_aliases) do
-    case extract(text, repo_aliases) do
-      [] ->
+  def reply(text, aliases) do
+    case extract(text, aliases) do
+      {[], []} ->
         nil
-      links ->
-        links_with_titles(links)
+      {github_links, clubhouse_links} ->
+        github_links_with_titles(github_links)
+        |> Enum.concat(clubhouse_links_with_titles(clubhouse_links))
+        |> Enum.join("\n")
     end
   end
 
-  defp links_with_titles(links) do
+  defp github_links_with_titles(links) do
     issues =
       for {_, repo, number} <- links do
         [owner, repo] = String.split(repo, "/", trim: true)
         {owner, repo, number}
       end
 
-    pids =
-      for {owner, repo, number} <- issues do
-        Task.async(fn -> @github.get_issue(owner, repo, number) end)
-      end
-
-    for {link, pid} <- Enum.zip(links, pids) do
-      case Task.await(pid) do
-        {:ok, %Issue{title: title}} ->
-          github_link(link) <> " - " <> title
-        {:error, reason} ->
-          Logger.warn("error: #{inspect reason}")
-          github_link(link) <> " (error: couldn't fetch title)"
-      end
+    for {owner, repo, number} <- issues do
+      Task.async(fn -> @github.get_issue(owner, repo, number) end)
     end
-    |> Enum.join("\n")
+    |> to_slack_links(links, &GitHub.to_link/1)
+  end
+
+  defp clubhouse_links_with_titles(links) do
+    for {_orig, _project, token, number} <- links do
+      Task.async(fn -> @clubhouse.get_issue(token, number) end)
+    end
+    |> to_slack_links(links, &ClubHouse.to_link/1)
+  end
+
+  defp to_slack_links(pids, links, link_fn) do
+    for {link, pid} <- Enum.zip(links, pids) do
+      Task.await(pid) |> to_slack_link(link, link_fn)
+    end
+  end
+
+  defp to_slack_link({:ok, %{title: title}}, link, link_fn) do
+    link_fn.(link) <> " - " <> title
+  end
+  defp to_slack_link({:error, reason}, link, link_fn) do
+    Logger.warn("error: #{inspect reason}")
+    link_fn.(link) <> " (error: couldn't fetch title)"
   end
 
   @doc false
-  def extract(text, repo_aliases \\ %{}) do
-    repo_aliases = Map.merge(@default_repo_aliases, repo_aliases)
-    repo_pattern = "([a-z]+[a-z0-9-_\.]*[a-z0-9]*)"
+  def extract(text, %{} = config \\ %{}) do
+    github_repo_aliases = Map.get(config, :github_repo_aliases, %{})
+    clubhouse_project_aliases = Map.get(config, :clubhouse_project_aliases, %{})
+    {extract_github(text, github_repo_aliases), extract_clubhouse(text, clubhouse_project_aliases)}
+  end
 
-    Regex.scan(~r/#{repo_pattern}#(\d+)/i, String.downcase(text))
-    |> Enum.flat_map(fn [orig, repo_alias, number] ->
-      case Map.fetch(repo_aliases, repo_alias) do
-        {:ok, repo} -> [{orig, repo, String.to_integer(number)}]
+  defp extract_github(text, repo_aliases) do
+    repo_aliases = Map.merge(@default_repo_aliases, repo_aliases)
+    pattern = ~r/#{@project_pattern}#(\d+)/i
+    do_extract(text, repo_aliases, pattern, fn(orig, repo, number) ->
+      {orig, repo, number}
+    end)
+  end
+
+  defp extract_clubhouse(text, project_aliases) do
+    pattern = ~r/#{@project_pattern}!(\d+)/i
+    do_extract(text, project_aliases, pattern, fn(orig, {project, token}, number) ->
+      {orig, project, token, number}
+    end)
+  end
+
+  defp do_extract(text, aliases, pattern, to_result_fn) do
+    Regex.scan(pattern, String.downcase(text))
+    |> Enum.flat_map(fn [orig, alias, number] ->
+      case Map.fetch(aliases, alias) do
+        {:ok, repo} -> [to_result_fn.(orig, repo, String.to_integer(number))]
         :error -> []
       end
     end)
     |> Enum.uniq
   end
-
-  defp github_link({orig, repo, number}),
-    do: "<#{github_url(repo, number)}|#{orig}>"
-
-  defp github_url(repo, number),
-    do: "https://github.com/#{repo}/issues/#{number}"
 end

--- a/lib/slack_autolinker/bot.ex
+++ b/lib/slack_autolinker/bot.ex
@@ -33,9 +33,16 @@ defmodule SlackAutolinker.Bot do
 
   defp config do
     %{github_repo_aliases: Application.get_env(:slack_autolinker, :github_repo_aliases) |> Poison.decode!(),
-      clubhouse_project_aliases: Application.get_env(:slack_autolinker, :clubhouse_project_aliases) |> Poison.decode!(),
+      clubhouse_project_aliases: Application.get_env(:slack_autolinker, :clubhouse_project_aliases) |> Poison.decode!() |> to_clubhouse_aliases(),
       username: Application.get_env(:slack_autolinker, :username),
       icon_emoji: Application.get_env(:slack_autolinker, :icon_emoji),
       icon_url: Application.get_env(:slack_autolinker, :icon_url)}
+  end
+
+  defp to_clubhouse_aliases(aliases) do
+    aliases
+    |> Enum.map(fn({alias, %{"project" => project, "token" => token}}) ->
+      %{alias => {project, token}}
+    end)
   end
 end

--- a/lib/slack_autolinker/bot.ex
+++ b/lib/slack_autolinker/bot.ex
@@ -12,7 +12,7 @@ defmodule SlackAutolinker.Bot do
   def handle_event(%{subtype: "bot_message"}, _, state), do: {:ok, state}
   def handle_event(message = %{type: "message", text: text}, _slack, state) do
     config = config()
-    reply = SlackAutolinker.reply(normalize_text(text), config.repo_aliases)
+    reply = SlackAutolinker.reply(normalize_text(text), config)
 
     if reply do
       icon = if config.icon_url, do: %{icon_url: config.icon_url}, else: %{icon_emoji: config.icon_emoji}
@@ -32,7 +32,8 @@ defmodule SlackAutolinker.Bot do
   end
 
   defp config do
-    %{repo_aliases: Application.get_env(:slack_autolinker, :repo_aliases) |> Poison.decode!(),
+    %{github_repo_aliases: Application.get_env(:slack_autolinker, :github_repo_aliases) |> Poison.decode!(),
+      clubhouse_project_aliases: Application.get_env(:slack_autolinker, :clubhouse_project_aliases) |> Poison.decode!(),
       username: Application.get_env(:slack_autolinker, :username),
       icon_emoji: Application.get_env(:slack_autolinker, :icon_emoji),
       icon_url: Application.get_env(:slack_autolinker, :icon_url)}

--- a/lib/slack_autolinker/clubhouse.ex
+++ b/lib/slack_autolinker/clubhouse.ex
@@ -1,0 +1,58 @@
+defmodule SlackAutolinker.ClubHouse do
+  defmodule Issue do
+    defstruct [:number, :title]
+  end
+
+  @type token :: String.t
+  @type num   :: integer
+
+  @callback get_issue(token, num) :: {:ok, Issue.t} :: {:error, term}
+
+  def to_link({orig, project, _token, number}), do: "<#{clubhouse_url(project, number)}|#{orig}>"
+
+  defp clubhouse_url(project, number), do: "https://app.clubhouse.io/#{project}/story/#{number}"
+end
+
+defmodule SlackAutolinker.ClubHouse.Real do
+  @behaviour SlackAutolinker.ClubHouse
+  @api_url "https://api.clubhouse.io/api/v2"
+  alias SlackAutolinker.ClubHouse.Issue
+
+  # TODO search among epics too !!!
+  def get_issue(token, number) do
+    case request(token, "/stories/#{number}") do
+      {:ok, payload} ->
+        {:ok, %Issue{number: payload["id"], title: payload["name"]}}
+      other ->
+        other
+    end
+  end
+
+  defp request(token, path) do
+    url = @api_url <> path <> "?token=" <> token
+
+    case HTTPoison.get(url) do
+      {:ok, %HTTPoison.Response{body: body, status_code: 200}} ->
+        {:ok, Poison.decode!(body)}
+
+      {:ok, %HTTPoison.Response{} = response} ->
+        {:error, response}
+
+      {:error, %HTTPoison.Error{} = error} ->
+        {:error, error}
+    end
+  end
+end
+
+defmodule SlackAutolinker.ClubHouse.Fake do
+  @behaviour SlackAutolinker.ClubHouse
+  alias SlackAutolinker.ClubHouse.Issue
+
+  def get_issue(_token, 404) do
+    {:error, :fake_reason}
+  end
+
+  def get_issue(_token, number) do
+    {:ok, %Issue{number: number, title: "Test: #{number}"}}
+  end
+end

--- a/lib/slack_autolinker/github.ex
+++ b/lib/slack_autolinker/github.ex
@@ -8,6 +8,10 @@ defmodule SlackAutolinker.GitHub do
   @type num   :: integer
 
   @callback get_issue(owner, repo, num) :: {:ok, Issue.t} :: {:error, term}
+
+  def to_link({orig, repo, number}), do: "<#{github_url(repo, number)}|#{orig}>"
+
+  defp github_url(repo, number), do: "https://github.com/#{repo}/issues/#{number}"
 end
 
 defmodule SlackAutolinker.GitHub.Real do

--- a/test/slack_autolinker_test.exs
+++ b/test/slack_autolinker_test.exs
@@ -3,28 +3,51 @@ defmodule SlackAutolinkerTest do
   doctest SlackAutolinker, import: true
   import SlackAutolinker
 
-  test "reply" do
-    repo_aliases = %{"bb" => "aa/bb"}
+  describe "reply" do
+    test "common" do
+      assert reply("", %{}) == nil
+    end
 
-    assert reply("", %{}) == nil
+    test "github" do
+      repo_aliases = %{"bb" => "aa/bb"}
 
+      assert reply("See: bb#1, bb#2.", %{github_repo_aliases: repo_aliases}) ==
+               "<https://github.com/aa/bb/issues/1|bb#1> - Test: aa/bb#1\n" <>
+               "<https://github.com/aa/bb/issues/2|bb#2> - Test: aa/bb#2"
 
-    assert reply("See: bb#1, bb#2.", repo_aliases) ==
-      "<https://github.com/aa/bb/issues/1|bb#1> - Test: aa/bb#1\n" <>
-      "<https://github.com/aa/bb/issues/2|bb#2> - Test: aa/bb#2"
+      assert reply("See: bb#404.", %{github_repo_aliases: repo_aliases}) ==
+               "<https://github.com/aa/bb/issues/404|bb#404> (error: couldn't fetch title)"
+    end
 
-    assert reply("See: bb#404.", repo_aliases) ==
-      "<https://github.com/aa/bb/issues/404|bb#404> (error: couldn't fetch title)"
+    test "clubhouse" do
+      project_aliases = %{"cb" => {"clubbase", "token"}}
+
+      assert reply("See: cb!1, cb!2.", %{clubhouse_project_aliases: project_aliases}) ==
+               "<https://app.clubhouse.io/clubbase/story/1|cb!1> - Test: 1\n" <>
+               "<https://app.clubhouse.io/clubbase/story/2|cb!2> - Test: 2"
+
+      assert reply("See: cb!404.", %{clubhouse_project_aliases: project_aliases}) ==
+               "<https://app.clubhouse.io/clubbase/story/404|cb!404> (error: couldn't fetch title)"
+    end
   end
 
-  test "extract" do
-    assert extract("See: bb#10.") == []
+  describe "extract" do
+    test "common" do
+      assert extract("See: bb#10.") == {[], []}
+    end
 
-    repo_aliases = %{"bb" => "aa/bb"}
-    assert extract("See: bb#10.", repo_aliases) == [{"bb#10", "aa/bb", 10}]
+    test "github" do
+      repo_aliases = %{"bb" => "aa/bb"}
 
-    # uniqueness
-    repo_aliases = %{"bb" => "aa/bb"}
-    assert extract("See: bb#10, bb#10.", repo_aliases) == [{"bb#10", "aa/bb", 10}]
+      assert extract("See: bb#10.", %{github_repo_aliases: repo_aliases}) == {[{"bb#10", "aa/bb", 10}], []}
+      assert extract("See: bb#10, bb#10.", %{github_repo_aliases: repo_aliases}) == {[{"bb#10", "aa/bb", 10}], []} # uniqueness
+    end
+
+    test "clubhouse" do
+      project_aliases = %{"cb" => {"clubbase", "token"}}
+
+      assert extract("See: cb!10.", %{clubhouse_project_aliases: project_aliases}) == {[], [{"cb!10", "clubbase", "token", 10}]}
+      assert extract("See: cb!10, cb!10.", %{clubhouse_project_aliases: project_aliases}) == {[], [{"cb!10", "clubbase", "token", 10}]} # uniqueness
+    end
   end
 end


### PR DESCRIPTION
GH stuff expects `cb#123`, CH expects `cb!123`.
Currently only stories, but epics can easily be added as well.

With deployment:
- rename env `BOT_REPO_ALIASES` to `GITHUB_REPO_ALIASES`
- add `CLUBHOUSE_PROJECT_ALIASES` 

Each project in CH has it's own tokens, so unfortunately, couldn't find a better way than to merge tokens with projects. So, `CLUBHOUSE_PROJECT_ALIASES` would be something like:
```json
{
  "cb": {
    "project": "clubbase",
    "token": "..."
  },
  "lisa": {
    "project": "lisa3",
    "token": "..."
  }
}
```
This adds repetition of tokens, maybe there's a better way.