### PR TITLE
Move to heroku-22 stack

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 22.3.4.26
-elixir 1.9.4-otp-22
+erlang 25.2.1
+elixir 1.14.3-otp-25

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "name": "slack_autolinker",
-  "stack": "heroku-20",
+  "stack": "heroku-22",
   "scripts": {},
   "env": {
     "BOT_ICON_EMOJI": ":construction:",

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,2 @@
-erlang_version=22.3.4.26
-elixir_version=1.9.4
+erlang_version=25.2.1
+elixir_version=1.14.3


### PR DESCRIPTION
Ref https://github.com/socialpaymentsbv/billing-engine/issues/12496

Heroku is deprecating stack 20 so this PR updates the app to stack 22