### PR TITLE
Upgrade websocket client

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule SlackAutolinker.Mixfile do
       {:plug, "~> 1.0"},
       {:poison, "~> 3.0"},
       {:slack, "~> 0.23.5"},
+      {:websocket_client, "~> 1.4", override: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -18,5 +18,5 @@
   "slack": {:hex, :slack, "0.23.5", "f6f756f7038d8e901b58f7c49ff1f5bd43d32f6bbd1ee5950752f17d3ad353bb", [:mix], [{:httpoison, "~> 1.2", [hex: :httpoison, repo: "hexpm", optional: false]}, {:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:websocket_client, "~> 1.2.4", [hex: :websocket_client, repo: "hexpm", optional: false]}], "hexpm", "d4f3c9afabd03ce016130ff7cba7d49518c1048ee99a8f9b81eb6f48f5719373"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
-  "websocket_client": {:hex, :websocket_client, "1.2.4", "14ec1ca4b6d247b44ccd9a80af8f6ca98328070f6c1d52a5cb00bc9d939d63b8", [:rebar3], [], "hexpm", "295a79cce15c208e03a545073f1318e97e7780aa9f2415e825cb9e338aecc305"},
+  "websocket_client": {:hex, :websocket_client, "1.5.0", "e825f23c51a867681a222148ed5200cc4a12e4fb5ff0b0b35963e916e2b5766b", [:rebar3], [], "hexpm", "2b9b201cc5c82b9d4e6966ad8e605832eab8f4ddb39f57ac62f34cb208b68de9"},
 }


### PR DESCRIPTION
Ref #15 

### Issue
The websocket_client 1.2.4 library used by the slack package doesn't work with erlang 25.
Unfortunately the [slack library] seems to be abandoned and we're already on it's latest version.

### Temporary solution

This PR forces the autolinker to use a newer version of websocket_client even if the slack library says otherwise. The reason why this is a temporary solution is because this slack bot is a legacy bot and will removed at the end of March 2025

<img width="1494" alt="image" src="https://github.com/user-attachments/assets/00f67de2-0d12-438f-a3ab-662b2d8c508d" />

